### PR TITLE
Add Arbitrary Batched Verifiable Tokens

### DIFF
--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -42,9 +42,8 @@ The base Privacy Pass issuance protocol
 which can either be publicly verifiable or not. While it is possible to run
 multiple instances of the issuance protocol in parallel, e.g., over a
 multiplexed transport such as HTTP/3 {{?HTTP3=RFC9114}} or by orchestrating multiple
-HTTP requests, these ad-hoc solutions varies from one implementation to the next. In
-addition, they cannot take advantage of cryptographic optimisations, and their cost
-always scales linearly with the number of instances.
+HTTP requests, these ad-hoc solutions vary based on transport protocol support. In
+addition, in some cases, they cannot take advantage of cryptographic optimizations.
 
 The first variant of the issuance protocol builds upon the privately verifiable
 issuance protocol in {{ISSUANCE}} that uses VOPRF {{!OPRF=I-D.irtf-cfrg-voprf}},

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -62,7 +62,7 @@ to be used with the PrivateToken HTTP authentication scheme defined in
 
 # Motivation
 
-Privacy Pass Tokens (as defines in
+Privacy Pass tokens (as defined in {{ARCHITECTURE}} and
 {{!ISSUANCE=I-D.ietf-privacypass-protocol}}) offer a simple way to unlink the
 issuance from the redemption. The base protocol however only allows for a single
 token to be issued at a time for every challenge. In some cases, especially

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -410,10 +410,10 @@ The issuer creates a BatchTokenResponse structured as follows:
 ~~~tls
 struct {
   TokenResponse token_response<0..2^16-1>; /* Defined by token_type */
-} InnerTokenResponse;
+} OptionalTokenResponse;
 
 struct {
-  InnerTokenResponse token_responses<0..2^16-1>;
+  OptionalTokenResponse token_responses<0..2^16-1>;
 } BatchTokenResponse
 ~~~
 

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -411,7 +411,6 @@ Content-Length: <Length of BatchTokenResponse>
 <Bytes containing the BatchTokenResponse>
 ~~~
 
-An Issuer MAY accept streamed request, and MAY provide TokenResponse to the Client as they are ready.
 
 
 ## Finalization {#arbitrary-finalization}

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -343,7 +343,7 @@ The Client then creates a BatchedTokenRequest structured as follows:
 struct {
   uint16_t token_type;
   TokenRequest token_requests<0..2^16-1>;
-} BatchedTokenRequest
+} BatchTokenRequest
 ~~~
 
 The structure fields are defined as follows:

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -63,8 +63,8 @@ to be used with the PrivateToken HTTP authentication scheme defined in
 # Motivation
 
 Privacy Pass tokens (as defined in {{ARCHITECTURE}} and
-{{!ISSUANCE=I-D.ietf-privacypass-protocol}}) offer a simple way to unlink the
-issuance from the redemption. The base protocol however only allows for a single
+{{!ISSUANCE=I-D.ietf-privacypass-protocol}}) are unlinkable during issuance and redemption.
+The basic issuance protocols defined in {{RFC9578}} however only allow for a single
 token to be issued at a time for every challenge. In some cases, especially
 where a large number of clients need to fetch a large number of tokens, this may
 introduce performance bottlenecks.

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -443,7 +443,6 @@ Content-Length: <Length of BatchTokenResponse>
 
 The Client tries to deserialize the i-th element
 of BatchTokenResponse.token_responses using the protocol associated to BatchTokenRequest.token_type.
-
 If the element has a size of 0, the Client MUST ignore this token, and continue processing the next token.
 The Client finalizes each deserialized TokenResponse using the matching TokenRequest according
 to the corresponding finalization procedure defined by the token type.

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -417,16 +417,10 @@ struct {
 } BatchTokenResponse
 ~~~
 
-The structure fields are defined as follows:
-
-- "token_response" are serialized TokenResponse, in network byte order,
-as defined by their token type. A size 0 indicates that the Issuer
-failed or refused to issue the associated TokenRequest.
-
-- "token_responses" are serialised InnerTokenResponses. The number of
-token_responses, as a 2-octet integer, is prepended to the serialized
-InnerTokenResponses This matches the number of incoming
-token_requests.
+BatchTokenResponse.token_responses is a vector of OptionalTokenResponses, length
+prefixed with two bytes. OptionalTokenResponse.token_response is a length-prefix-encoded
+TokenResponse, where a length of 0 indicates that the Issuer failed or refused to issue the
+associated TokenRequest.
 
 The Issuer generates an HTTP response with status code 200 whose content
 consists of TokenResponse, with the content type set as

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -68,7 +68,7 @@ The basic issuance protocols defined in {{RFC9578}} however only allow for a sin
 token to be issued at a time for every challenge. In some cases, especially
 where a large number of clients need to fetch a large number of tokens, this may
 introduce performance bottlenecks.
-The Batched Token Issuance Protocol improves
+Batched token issuance improves
 upon the basic Privately Verifiable Token issuance protocol in the following key
 ways:
 

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -445,9 +445,8 @@ The Client tries to deserialize the i-th element
 of BatchTokenResponse.token_responses using the protocol associated to BatchTokenRequest.token_type.
 
 If the element has a size of 0, the Client MUST ignore this token, and continue processing the next token.
-
-If the issuance protocol defines it, the Client finalizes these tokens. If this function fails, the Client aborts the protocol.
-Token verification is unchanged.
+The Client finalizes each deserialized TokenResponse using the matching TokenRequest according
+to the corresponding finalization procedure defined by the token type.
 
 # Security considerations {#security-considerations}
 

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -33,12 +33,12 @@ one token at a time and for issuers to issue more than one token at a time.
 # Introduction
 
 This document specifies two Privacy Pass issuance protocols (as
-defined in {{!ARCH=I-D.ietf-privacypass-architecture}}) that allow for batched
+defined in {{!RFC9576=I-D.ietf-privacypass-architecture}}) that allow for batched
 issuance of tokens. This allows clients to request more than one token at a time
 and for issuers to issue more than one token at a time.
 
 The base Privacy Pass issuance protocol
-{{!ISSUANCE=I-D.ietf-privacypass-protocol}} defines stateless anonymous tokens,
+{{!RFC9578=I-D.ietf-privacypass-protocol}} defines stateless anonymous tokens,
 which can either be publicly verifiable or not. While it is possible to run
 multiple instances of the issuance protocol in parallel, e.g., over a
 multiplexed transport such as HTTP/3 {{?HTTP3=RFC9114}} or by orchestrating multiple
@@ -46,7 +46,7 @@ HTTP requests, these ad-hoc solutions vary based on transport protocol support. 
 addition, in some cases, they cannot take advantage of cryptographic optimizations.
 
 The first variant of the issuance protocol builds upon the privately verifiable
-issuance protocol in {{ISSUANCE}} that uses VOPRF {{!OPRF=I-D.irtf-cfrg-voprf}},
+issuance protocol in {{RFC9578}} that uses VOPRF {{!OPRF=I-D.irtf-cfrg-voprf}},
 and allows for batched issuance of tokens. This allows clients to request more
 than one token at a time and for issuers to issue more than one token at a
 time. In effect, private batched issuance performance scales better than linearly.
@@ -62,8 +62,8 @@ to be used with the PrivateToken HTTP authentication scheme defined in
 
 # Motivation
 
-Privacy Pass tokens (as defined in {{ARCHITECTURE}} and
-{{!ISSUANCE=I-D.ietf-privacypass-protocol}}) are unlinkable during issuance and redemption.
+Privacy Pass tokens (as defined in {{RFC9576}} and
+{{!RFC9578=I-D.ietf-privacypass-protocol}}) are unlinkable during issuance and redemption.
 The basic issuance protocols defined in {{RFC9578}} however only allow for a single
 token to be issued at a time for every challenge. In some cases, especially
 where a large number of clients need to fetch a large number of tokens, this may
@@ -82,12 +82,12 @@ to be sent that encompasses multiple tokens. The cost remains linear.
 
 # Batched Privately Verifiable Token
 
-This section describes a batched issuance protocol for select token types, including 0x0001 (defined in {{RFC9578}}) and 0xF91A (defined in this document). 
+This section describes a batched issuance protocol for select token types, including 0x0001 (defined in {{RFC9578}}) and 0xF91A (defined in this document).
 
 ## Client-to-Issuer Request {#client-to-issuer-request}
 
 Except where specified otherwise, the client follows the same protocol as
-described in {{ISSUANCE, Section 5.1}}.
+described in {{RFC9578, Section 5.1}}.
 
 The Client first creates a context as follows:
 
@@ -159,7 +159,7 @@ Content-Length: <Length of BatchTokenRequest>
 ## Issuer-to-Client Response {#issuer-to-client-response}
 
 Except where specified otherwise, the client follows the same protocol as
-described in {{ISSUANCE, Section 5.2}}.
+described in {{RFC9578, Section 5.2}}.
 
 Upon receipt of the request, the Issuer validates the following conditions:
 
@@ -326,7 +326,7 @@ struct {
 ~~~
 
 If the FinalizeBatch function fails, the Client aborts the protocol. Token
-verification works exactly as specified in {{ISSUANCE}}.
+verification works exactly as specified in {{RFC9578}}.
 
 # Arbitrary Batched Token Issuance
 
@@ -335,7 +335,7 @@ This section describes an issuance protocol mechanism for issuing multiple token
 ## Client-to-Issuer Request {#arbitrary-client-to-issuer-request}
 
 The Client first creates all TokenRequest it wants to batch. To do so, the client follows
-protocol describing issuance, such as {{ISSUANCE, Section 5.1}} or {{ISSUANCE, Section 6.1}}.
+protocol describing issuance, such as {{RFC9578, Section 5.1}} or {{RFC9578, Section 6.1}}.
 
 The Client then creates a BatchedTokenRequest structured as follows:
 
@@ -354,7 +354,7 @@ The structure fields are defined as follows:
 
 - "token_type" is a 2-octet integer, which matches the type of the TokenRequests in the batch.
 
-- "token_requests" are serialized TokenRequests, in network byte order. The number of token_requests, as a 2-octet integer, is prepended to the serialized TokenRequests. In addition, the 2-octet integer length of each TokenRequest is prepended to the serialized TokenRequests. TokenRequest MUST start with a "token_type", not included in the inner opaque token_request attribute. 
+- "token_requests" are serialized TokenRequests, in network byte order. The number of token_requests, as a 2-octet integer, is prepended to the serialized TokenRequests. In addition, the 2-octet integer length of each TokenRequest is prepended to the serialized TokenRequests. TokenRequest MUST start with a "token_type", not included in the inner opaque token_request attribute.
 
 The Client then generates an HTTP POST request to send to the Issuer Request
 URL, with the BatchTokenRequest as the content. The media type for this request
@@ -460,7 +460,7 @@ following entry:
 * Private Metadata: N
 * Nk: 32
 * Nid: 32
-* Reference: {{ISSUANCE, Section 5}}
+* Reference: {{RFC9578, Section 5}}
 * Notes: None
 
 ## Media Types

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -82,6 +82,8 @@ to be sent ........
 
 # Batched Privately Verifiable Token
 
+This section describes a batched issuance protocol for select token types, including 0x0001 (defined in {{RFC9578}}) and 0xF91A (defined in this document). 
+
 ## Client-to-Issuer Request {#client-to-issuer-request}
 
 Except where specified otherwise, the client follows the same protocol as

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -56,7 +56,7 @@ which allows for batched issuance of arbitrary token types. This allows clients 
 than one token at a time and for issuers to issue more than one token at a
 time. In effect, arbitrary batched tokens performance is linear.
 
-This batched issuance protocol registers two new token types ({{iana-token-type}}),
+This batched issuance protocol registers one new token type ({{iana-token-type}}),
 to be used with the PrivateToken HTTP authentication scheme defined in
 {{!AUTHSCHEME=I-D.ietf-privacypass-auth-scheme}}.
 

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -32,8 +32,8 @@ one token at a time and for issuers to issue more than one token at a time.
 
 # Introduction
 
-This document specifies two variants of the Privacy Pass issuance protocol (as
-defined in {{!ARCH=I-D.ietf-privacypass-architecture}}) that allows for batched
+This document specifies two Privacy Pass issuance protocols (as
+defined in {{!ARCH=I-D.ietf-privacypass-architecture}}) that allow for batched
 issuance of tokens. This allows clients to request more than one token at a time
 and for issuers to issue more than one token at a time.
 

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -328,7 +328,9 @@ struct {
 If the FinalizeBatch function fails, the Client aborts the protocol. Token
 verification works exactly as specified in {{ISSUANCE}}.
 
-# Arbitrary Batched Verifiable Token
+# Arbitrary Batched Token Issuance
+
+This section describes an issuance protocol mechanism for issuing multiple tokens in one round trip between Client and Issuer. An arbitrary batched token request can contain token requests for any token type.
 
 ## Client-to-Issuer Request {#arbitrary-client-to-issuer-request}
 

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -363,19 +363,6 @@ The structure fields are defined as follows:
 
 - "token_requests" are serialized TokenRequests, in network byte order. The number of token_requests, as a 2-octet integer, is prepended to the serialized TokenRequests. In addition, the 2-octet integer length of each TokenRequest is prepended to the serialized TokenRequests.
 
-~~~tls
-struct {
-   uint16_t token_type;
-   select (token_type) {
-      case (0x0001): /* Type VOPRF(P-384, SHA-384), RFC 9578 */
-         uint8_t truncated_token_key_id;
-         uint8_t blinded_msg[Ne];
-      case (0x0002): /* Type Blind RSA (2048-bit), RFC 9578 */
-         uint8_t truncated_token_key_id;
-         uint8_t blinded_msg[Nk];
-   }
-} TokenRequest;
-~~~
 
 The Client then generates an HTTP POST request to send to the Issuer Request
 URL, with the BatchTokenRequest as the content. The media type for this request


### PR DESCRIPTION
Allow TokenRequests to be batched. While this scales linearly, it provides a go to method to batch token request for publicly verifiable, or even rate limit tokens.

Closes #12 