### PR TITLE
Fix Arbitrary batched tokens structures description

### DIFF
--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -395,7 +395,7 @@ struct {
 
 The structure fields are defined as follows:
 
-- TokenRequest's "token_type" is a 2-octet integer. TokenRequest MUST be prefixed
+- TokenRequest's "token_type" is a 2-octet integer. TokenRequest MUST always start
   with a uint16 "token_type" indicating the token type. The rest of the
   structure follows based on that type, within the inner opaque token_request
   attribute. The above definition corresponds to TokenRequest from {{RFC9578}}.

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -404,14 +404,6 @@ The structure fields are defined as follows:
 
 - "token_requests" is an array of TokenRequest satisfying the above constraint.
 
-Note that when serialiazed in network byte order, BatchTokenRequest:
-
-- is prepended with a 2-octet integer representing the length of its underlying
-  byte array. This is not the number of TokenRequest.
-
-- has each of its TokenRequest serialized in network byte order. Specifically,
-  this implies each TokenRequest is prepended with its length as a 2-octet
-  integer.
 
 The Client then generates an HTTP POST request to send to the Issuer Request
 URL, with the BatchTokenRequest as the content. The media type for this request

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -399,8 +399,8 @@ The structure fields are defined as follows:
   with a uint16 "token_type" indicating the token type. The rest of the
   structure follows based on that type, within the inner opaque token_request
   attribute. The above definition corresponds to TokenRequest from {{RFC9578}}.
-  For TokenRequest not defined in {{RFC9578}}, they MAY be used as long as they
-  are prefixed with a 2-octet token_type.
+  A TokenRequest with a token type not defined in {{RFC9578}} MAY be used but
+  MUST always start with a 2-octet token_type.
 
 - "token_requests" is an array of TokenRequest satisfying the above constraint.
 

--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -395,18 +395,23 @@ struct {
 
 The structure fields are defined as follows:
 
-- "token_type" is a 2-octet integer. TokenRequest MUST be prefixed with a uint16
-  "token_type" indicating the token type. The rest of the structure follows
-  based on that type, within the inner opaque token_request attribute. The above
-  definition corresponds to TokenRequest from {{RFC9578}}. For TokenRequest not
-  defined in {{RFC9578}}, they MAY be used as long as they are prefixed with a
-  2-octet token_type.
+- TokenRequest's "token_type" is a 2-octet integer. TokenRequest MUST be prefixed
+  with a uint16 "token_type" indicating the token type. The rest of the
+  structure follows based on that type, within the inner opaque token_request
+  attribute. The above definition corresponds to TokenRequest from {{RFC9578}}.
+  For TokenRequest not defined in {{RFC9578}}, they MAY be used as long as they
+  are prefixed with a 2-octet token_type.
 
-- "token_requests" are serialized TokenRequests, in network byte order. The
-  number of token_requests, as a 2-octet integer, is prepended to the serialized
-  TokenRequests. In addition, the 2-octet integer length of each TokenRequest is
-  prepended to the serialized TokenRequests.
+- "token_requests" is an array of TokenRequest satisfying the above constraint.
 
+Note that when serialiazed in network byte order, BatchTokenRequest:
+
+- is prepended with a 2-octet integer representing the length of its underlying
+  byte array. This is not the number of TokenRequest.
+
+- has each of its TokenRequest serialized in network byte order. Specifically,
+  this implies each TokenRequest is prepended with its length as a 2-octet
+  integer.
 
 The Client then generates an HTTP POST request to send to the Issuer Request
 URL, with the BatchTokenRequest as the content. The media type for this request


### PR DESCRIPTION
The description of arbitrary batched tokens structures did not satisfy with standard tls serialisation, and was ocnfusing.

This commit addresses:

* token_requests array is prefixed with the length of its underlying byte array. The previous spec refered to the number of TokenRequest, which is incorrect.
* token_requests array is an array of TokenRequest. It's only when serialized that it contains serialized TokenRequest. The wording has been updated.
* TokenRequest serialization is not redefined. Its moved to a note instead of a struct definition.