### PR TITLE
Address comments from IANA early review

### DIFF
--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -569,6 +569,7 @@ following entry:
 * Private Metadata: N
 * Nk: 32
 * Nid: 32
+* Change controller: IETF
 * Reference: {{RFC9578, Section 5}}
 * Notes: None
 


### PR DESCRIPTION
Add a IETF as the change controller for the newly registered token type 0x0005.

This has been prompted by IANA early review of the draft.

This change matches [RFC 9578](https://www.rfc-editor.org/rfc/rfc9578.html#section-8.2.1) model.