### PR TITLE
Nk for 0x0005 should match RFC9497 Section 4.1

### DIFF
--- a/draft-ietf-privacypass-batched-tokens.md
+++ b/draft-ietf-privacypass-batched-tokens.md
@@ -588,7 +588,7 @@ following entry:
 * Publicly Verifiable: N
 * Public Metadata: N
 * Private Metadata: N
-* Nk: 32
+* Nk: 64
 * Nid: 32
 * Change controller: IETF
 * Reference: {{RFC9578, Section 5}}


### PR DESCRIPTION
Nk is set as 32. This does not match Nh defined in [RFC 9497 Section 4.1](https://www.rfc-editor.org/rfc/rfc9497#section-4.1).

It should be 64 instead.

This is what the Rust implementation is using, as well as the underwork Go implementation.

If that's not the right value, we should fix it.

@raphaelrobert 